### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,7 +6,7 @@
 # Datatypes (KEYWORD1)
 #######################################
 ReSpeaker	KEYWORD1
-Pixels		KEYWORD1
+Pixels	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
@@ -16,13 +16,13 @@ begin	KEYWORD2
 play	KEYWORD2
 exec	KEYWORD2
 pixels	KEYWORD2
-set_console		KEYWORD2
+set_console	KEYWORD2
 calibrate_touch	KEYWORD2
-read_touch		KEYWORD2
+read_touch	KEYWORD2
 detect_touch	KEYWORD2
-set_touch_threshold		KEYWORD2
+set_touch_threshold	KEYWORD2
 attach_touch_handler	KEYWORD2
-attach_spi_handler		KEYWORD2
+attach_spi_handler	KEYWORD2
 attach_spi_raw_handler	KEYWORD2
 
 set_color	KEYWORD2
@@ -32,7 +32,7 @@ get_brightness	KEYWORD2
 clear	KEYWORD2
 update	KEYWORD2
 number	KEYWORD2
-RGB		KEYWORD2
+RGB	KEYWORD2
 rainbow	KEYWORD2
 wheel	KEYWORD2
 


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords